### PR TITLE
Fix displaying of Builds

### DIFF
--- a/www/md_base/src/app/builds/builder/builder.controller.coffee
+++ b/www/md_base/src/app/builds/builder/builder.controller.coffee
@@ -12,7 +12,7 @@ class Builder extends Controller
 
         data = @dataService.open().closeOnDestroy($scope)
 
-        @builderid = @$state.params.builderid
+        @builderid = parseInt(@$state.params.builderid)
         data.getBuilders(@builderid).onChange = (data) =>
             if data.length == 0
                 alert 'Builder not found!'

--- a/www/md_base/src/app/builds/builder/builds.builder.tpl.jade
+++ b/www/md_base/src/app/builds/builder/builds.builder.tpl.jade
@@ -27,5 +27,5 @@ md-tabs.builder-tabs(
   md-tab(ng-disabled="!false", ng-if="builder.buildTabs.length > 0")
     md-tab-label
       md-icon.tab-divider(md-svg-icon="arrow-down")
-  md-tab.build-tab(label="Build #{{ number }}", ng-repeat="number in builder.buildTabs")
+  md-tab.build-tab(label="Build \#{{ number }}", ng-repeat="number in builder.buildTabs")
 div.builder-content(ui-view="")

--- a/www/md_base/src/app/builds/builder/forcedialog/forcedialog.controller.coffee
+++ b/www/md_base/src/app/builds/builder/forcedialog/forcedialog.controller.coffee
@@ -23,7 +23,7 @@ class ForceDialog extends Controller
             @field_errors = null
 
     forceBuild: (param) ->
-        res = @dataService.control 'forceschedulers/force', 'force', param
+        res = @dataService.control 'forceschedulers', 'force', 'force', param
         res.then (=> @forceBuildSuccess()), (data) => @forceBuildFail(data.error)
 
     constructor: (@builder, @scheduler, @dataService, @$mdDialog) ->

--- a/www/md_base/src/app/builds/builder/tabs/builds.builder.buildtab.tpl.jade
+++ b/www/md_base/src/app/builds/builder/tabs/builds.builder.buildtab.tpl.jade
@@ -1,6 +1,6 @@
 div.build-tab(ng-if="buildtab.build && builder.info.builderid")
   div.tab-manage-bar(layout="row")
-    build-item(flex, build="buildtab.build", builder="builder.info")
+    build-item(flex, build="buildtab.build")
     a.md-button.md-primary(ng-click="builder.closeBuildTab(buildtab.number)") close
   build-info(build="buildtab.build")
   div.build-steps(ng-if="buildtab.steps.length > 0")

--- a/www/md_base/src/app/common/directives/buildinfo/buildinfo.directive.coffee
+++ b/www/md_base/src/app/common/directives/buildinfo/buildinfo.directive.coffee
@@ -21,11 +21,11 @@ class _BuildInfo extends Controller
     raw_properties: {}
 
     constructor: ->
-        @build.loadChanges().then (changes) =>
+        @build.loadChanges().onChange = (changes) =>
             @changes = changes
             @change_owners = @processOwners(_.uniq(change.author for change in changes))
 
-            @build.loadProperties().then (data) =>
+            @build.loadProperties().onChange = (data) =>
                 @processProperties(data[0])
 
     processOwners: (owners = []) ->

--- a/www/md_base/src/app/common/directives/buildstatus/buildstatus.directive.coffee
+++ b/www/md_base/src/app/common/directives/buildstatus/buildstatus.directive.coffee
@@ -30,5 +30,5 @@ class _BuildStatus extends Controller
                 @status_class = 'unknown'
                 @icon = 'pending'
 
-        $scope.$watch 'status.build', updateBuild, true
+        $scope.$watch 'status.build', updateBuild
 

--- a/www/md_base/src/app/common/directives/buildstep/buildstep.directive.coffee
+++ b/www/md_base/src/app/common/directives/buildstep/buildstep.directive.coffee
@@ -17,7 +17,7 @@ class _BuildStep extends Controller
     isExpanded: false
 
     constructor: ($scope, RESULTS_TEXT) ->
-        $scope.$watch 'buildstep.step', (=> @updateState(RESULTS_TEXT)), true
+        $scope.$watch 'buildstep.step', (=> @updateState(RESULTS_TEXT))
         @step.loadLogs()
 
     updateState: (RESULTS_TEXT) ->


### PR DESCRIPTION
I managed to make the builder and build page able to display. Now using `parseInt` to convert `builderid` into int.

I found some problems when trying to perform deep `$watch` operation on current `BuildInstance` objects. It causes  `$digest` error (recursively digest for too many times). I temporarily removed the `true` for deep watch. Not sure if it will cause a delay or no updating when the status of a build is changed.

I found when a new build is triggered, it won't appears automatically in the list either. :-/ 