### PR TITLE
master/setup.py: publish buildbot.buildslave

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -152,6 +152,7 @@ setup_args = {
 
     'packages': [
         "buildbot",
+        "buildbot.buildslave",
         "buildbot.worker",
         "buildbot.worker.protocols",
         "buildbot.changes",


### PR DESCRIPTION
it was unpublished during the worker transition, but is necessary for the backward compatibility